### PR TITLE
Provide stateless access to multiple languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,42 @@ fmt.Println(lctime.Strftime("%c", time.Now()))
 // prints: lun 14 dic 2015 22:31:56 PST
 ```
 
+This is very easy if your application only has to translate to a single language.
+
+### Multiple Locales
+
+To do translation to multiple languages without having collisions, you can use 
+the [`StrftimeLoc`](https://godoc.org/github.com/variadico/lctime#StrftimeLoc) function. 
+It allows you to specify a locale along your time to be translated.
+
+```go
+	t := time.Date(2015, 12, 25, 3, 2, 1, 0, time.UTC)
+	txt, err := StrftimeLoc("es_MX", "%A, %d de %B de %Y", t)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println(txt)
+
+	// Prints viernes, 25 de diciembre de 2015
+```
+
+If you need to do several translations or need to pass your localizer as a parameter, you can use
+the [`NewLocalizer`](https://godoc.org/github.com/variadico/lctime#NewLocalizer) function.
+It allows you to localize several strings to the same language without having to specify it every time.
+
+```go
+	t := time.Date(2015, 12, 25, 3, 2, 1, 0, time.UTC)
+	l, err := NewLocalizer("da_DK")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println(l.Strftime("%A den %d. %B %Y", t))
+
+	// Prints: fredag den 25. december 2015
+```
+
 ## The problem with the Go standard library
 
 Go's standard library `time` is fine most of the time. However, it's currently

--- a/directives.go
+++ b/directives.go
@@ -10,49 +10,49 @@ import (
 )
 
 // pera returns the locale's abbreviated weekday name.
-func pera(t time.Time) string {
+func (lc *localeData) pera(t time.Time) string {
 	return lc.ShortDays[int(t.Weekday())]
 }
 
 // perA returns the locale's full weekday name.
-func perA(t time.Time) string {
+func (lc *localeData) perA(t time.Time) string {
 	return lc.Days[int(t.Weekday())]
 }
 
 // perb returns the locale's abbreviated month name.
-func perb(t time.Time) string {
+func (lc *localeData) perb(t time.Time) string {
 	return lc.ShortMonths[int(t.Month())-1]
 }
 
 // perB returns the locale's full month name.
-func perB(t time.Time) string {
+func (lc *localeData) perB(t time.Time) string {
 	return lc.Months[int(t.Month())-1]
 }
 
 // perc returns the locale's appropriate date and time representation.
-func perc(t time.Time) string {
-	return Strftime(lc.DateTime, t)
+func (lc *localeData) perc(t time.Time) string {
+	return lc.Strftime(lc.DateTime, t)
 }
 
 // perC returns the year divided by 100 and truncated to an integer, as a
 // decimal number.
-func perC(t time.Time) string {
+func (lc *localeData) perC(t time.Time) string {
 	return fmt.Sprint(t.Year() / 100)
 }
 
 // perd returns the day of the month as a decimal number [01,31].
-func perd(t time.Time) string {
+func (lc *localeData) perd(t time.Time) string {
 	return fmt.Sprintf("%02d", t.Day())
 }
 
 // perD returns the date formatted as %m/%d/%y.
-func perD(t time.Time) string {
-	return Strftime("%m/%d/%y", t)
+func (lc *localeData) perD(t time.Time) string {
+	return lc.Strftime("%m/%d/%y", t)
 }
 
 // pere returns the day of the month as a decimal number [1,31]; a single digit
 // is preceded by a space.
-func pere(t time.Time) string {
+func (lc *localeData) pere(t time.Time) string {
 	d := t.Day()
 	if d < 10 {
 		return fmt.Sprintf(" %d", d)
@@ -61,30 +61,30 @@ func pere(t time.Time) string {
 }
 
 // perF returns the date formatted as %Y-%m-%d.
-func perF(t time.Time) string {
-	return Strftime("%Y-%m-%d", t)
+func (lc *localeData) perF(t time.Time) string {
+	return lc.Strftime("%Y-%m-%d", t)
 }
 
 // perg returns the last 2 digits of the week-based year as a decimal number
 // [00,99].
-func perg(t time.Time) string {
+func (lc *localeData) perg(t time.Time) string {
 	y, _ := t.ISOWeek()
 	return fmt.Sprintf("%02d", y%100)
 }
 
 // perG returns the week-based year as a decimal number (for example, 1977).
-func perG(t time.Time) string {
+func (lc *localeData) perG(t time.Time) string {
 	y, _ := t.ISOWeek()
 	return fmt.Sprintf("%d", y)
 }
 
 // perH returns the hour (24-hour clock) as a decimal number [00,23].
-func perH(t time.Time) string {
+func (lc *localeData) perH(t time.Time) string {
 	return fmt.Sprintf("%02d", t.Hour())
 }
 
 // perI returns the hour (12-hour clock) as a decimal number [01,12].
-func perI(t time.Time) string {
+func (lc *localeData) perI(t time.Time) string {
 	hr := t.Hour() % 12
 	if hr == 0 {
 		hr = 12
@@ -94,27 +94,27 @@ func perI(t time.Time) string {
 }
 
 // perj returns the day of the year as a decimal number [001,366].
-func perj(t time.Time) string {
+func (lc *localeData) perj(t time.Time) string {
 	return fmt.Sprintf("%03d", t.YearDay())
 }
 
 // perm returns the month as a decimal number [01,12].
-func perm(t time.Time) string {
+func (lc *localeData) perm(t time.Time) string {
 	return fmt.Sprintf("%02d", t.Month())
 }
 
 // perM returns the minute as a decimal number [00,59].
-func perM(t time.Time) string {
+func (lc *localeData) perM(t time.Time) string {
 	return fmt.Sprintf("%02d", t.Minute())
 }
 
 // pern returns a newline.
-func pern(t time.Time) string {
+func (lc *localeData) pern(t time.Time) string {
 	return "\n"
 }
 
 // perp returns the locale's equivalent of either a.m. or p.m.
-func perp(t time.Time) string {
+func (lc *localeData) perp(t time.Time) string {
 	if t.Hour() < 12 {
 		return lc.AMPM[0]
 	}
@@ -122,33 +122,33 @@ func perp(t time.Time) string {
 }
 
 // perr returns the time in a.m. and p.m. notation.
-func perr(t time.Time) string {
-	return Strftime(lc.TimeAMPM, t)
+func (lc *localeData) perr(t time.Time) string {
+	return lc.Strftime(lc.TimeAMPM, t)
 }
 
 // perR returns the time formatted as %H:%M.
-func perR(t time.Time) string {
-	return Strftime("%H:%M", t)
+func (lc *localeData) perR(t time.Time) string {
+	return lc.Strftime("%H:%M", t)
 }
 
 // perS returns the second as a decimal number [00,60].
-func perS(t time.Time) string {
+func (lc *localeData) perS(t time.Time) string {
 	return fmt.Sprintf("%02d", t.Second())
 }
 
 // pert returns a tab.
-func pert(t time.Time) string {
+func (lc *localeData) pert(t time.Time) string {
 	return "\t"
 }
 
 // perT returns the time formatted as %H:%M:%S
-func perT(t time.Time) string {
-	return Strftime("%H:%M:%S", t)
+func (lc *localeData) perT(t time.Time) string {
+	return lc.Strftime("%H:%M:%S", t)
 }
 
 // peru returns the weekday as a decimal number [1,7], with 1 representing
 // Monday.
-func peru(t time.Time) string {
+func (lc *localeData) peru(t time.Time) string {
 	d := int(t.Weekday())
 	if d == 0 {
 		return "7"
@@ -160,7 +160,7 @@ func peru(t time.Time) string {
 // perU returns the week number of the year as a decimal number [00,53]. The
 // first Sunday of January is the first day of week 1; days in the new year
 // before this are in week 0.
-func perU(t time.Time) string {
+func (lc *localeData) perU(t time.Time) string {
 	_, wn := t.ISOWeek()
 	return fmt.Sprintf("%02d", wn)
 }
@@ -170,42 +170,42 @@ func perU(t time.Time) string {
 // or more days in the new year, then it is considered week 1. Otherwise, it is
 // the last week of the previous year, and the next week is week 1. Both January
 // 4th and the first Thursday of January are always in week 1.
-func perV(t time.Time) string {
+func (lc *localeData) perV(t time.Time) string {
 	_, wn := t.ISOWeek()
 	return fmt.Sprintf("%02d", wn)
 }
 
 // perw returns the weekday as a decimal number [0,6], with 0 representing
 // Sunday.
-func perw(t time.Time) string {
+func (lc *localeData) perw(t time.Time) string {
 	return fmt.Sprintf("%d", t.Weekday())
 }
 
 // perW returns the week number of the year as a decimal number [00,53]. The
 // first Monday of January is the first day of week 1; days in the new year
 // before this are in week 0.
-func perW(t time.Time) string {
+func (lc *localeData) perW(t time.Time) string {
 	_, wn := t.ISOWeek()
 	return fmt.Sprintf("%02d", wn-1)
 }
 
 // perx returns the locale's appropriate date representation.
-func perx(t time.Time) string {
-	return Strftime(lc.Date, t)
+func (lc *localeData) perx(t time.Time) string {
+	return lc.Strftime(lc.Date, t)
 }
 
 // perX returns the locale's appropriate time representation.
-func perX(t time.Time) string {
-	return Strftime(lc.Time, t)
+func (lc *localeData) perX(t time.Time) string {
+	return lc.Strftime(lc.Time, t)
 }
 
 // pery returns the last two digits of the year as a decimal number [00,99].
-func pery(t time.Time) string {
+func (lc *localeData) pery(t time.Time) string {
 	return fmt.Sprintf("%02d", t.Year()%100)
 }
 
 // perY returns the year as a decimal number (for example, 1997).
-func perY(t time.Time) string {
+func (lc *localeData) perY(t time.Time) string {
 	return fmt.Sprint(t.Year())
 }
 
@@ -215,19 +215,19 @@ func perY(t time.Time) string {
 // is zero, the standard time offset is used. If tm_isdst is greater than zero,
 // the daylight savings time offset is used. If tm_isdst is negative, no
 // characters are returned.
-func perz(t time.Time) string {
+func (lc *localeData) perz(t time.Time) string {
 	_, off := t.Zone()
 	return fmt.Sprintf("%+05d", off)
 }
 
 // perZ returns the timezone name or abbreviation, or by no bytes if no timezone
 // information exists.
-func perZ(t time.Time) string {
+func (lc *localeData) perZ(t time.Time) string {
 	tz, _ := t.Zone()
 	return tz
 }
 
 // perper returns a %.
-func perper(t time.Time) string {
+func (lc *localeData) perper(t time.Time) string {
 	return "%"
 }

--- a/directives_test.go
+++ b/directives_test.go
@@ -36,7 +36,7 @@ func TestPera(t *testing.T) {
 	for i, test := range tests {
 		SetLocale(test.locale)
 
-		if got := pera(test.input); got != test.want {
+		if got := lc.pera(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -73,7 +73,7 @@ func TestPerA(t *testing.T) {
 	for i, test := range tests {
 		SetLocale(test.locale)
 
-		if got := perA(test.input); got != test.want {
+		if got := lc.perA(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -110,7 +110,7 @@ func TestPerb(t *testing.T) {
 	for i, test := range tests {
 		SetLocale(test.locale)
 
-		if got := perb(test.input); got != test.want {
+		if got := lc.perb(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -147,7 +147,7 @@ func TestPerB(t *testing.T) {
 	for i, test := range tests {
 		SetLocale(test.locale)
 
-		if got := perB(test.input); got != test.want {
+		if got := lc.perB(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -184,7 +184,7 @@ func TestPerc(t *testing.T) {
 	for i, test := range tests {
 		SetLocale(test.locale)
 
-		if got := perc(test.input); got != test.want {
+		if got := lc.perc(test.input); got != test.want {
 			t.Error("locale:", test.locale)
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
@@ -200,7 +200,7 @@ func TestPerC(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := perC(test.input); got != test.want {
+		if got := lc.perC(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -215,7 +215,7 @@ func TestPerd(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := perd(test.input); got != test.want {
+		if got := lc.perd(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -230,7 +230,7 @@ func TestPerD(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := perD(test.input); got != test.want {
+		if got := lc.perD(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -246,7 +246,7 @@ func TestPere(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := pere(test.input); got != test.want {
+		if got := lc.pere(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -261,7 +261,7 @@ func TestPerF(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := perF(test.input); got != test.want {
+		if got := lc.perF(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -277,7 +277,7 @@ func TestPerg(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := perg(test.input); got != test.want {
+		if got := lc.perg(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -293,7 +293,7 @@ func TestPerG(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := perG(test.input); got != test.want {
+		if got := lc.perG(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -308,7 +308,7 @@ func TestPerH(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := perH(test.input); got != test.want {
+		if got := lc.perH(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -324,7 +324,7 @@ func TestPerI(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := perI(test.input); got != test.want {
+		if got := lc.perI(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -339,7 +339,7 @@ func TestPerj(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := perj(test.input); got != test.want {
+		if got := lc.perj(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -354,7 +354,7 @@ func TestPerm(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := perm(test.input); got != test.want {
+		if got := lc.perm(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -369,7 +369,7 @@ func TestPerM(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := perM(test.input); got != test.want {
+		if got := lc.perM(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -384,7 +384,7 @@ func TestPern(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := pern(test.input); got != test.want {
+		if got := lc.pern(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -421,7 +421,7 @@ func TestPerp(t *testing.T) {
 	for i, test := range tests {
 		SetLocale(test.locale)
 
-		if got := perp(test.input); got != test.want {
+		if got := lc.perp(test.input); got != test.want {
 			t.Error("locale:", test.locale)
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
@@ -459,7 +459,7 @@ func TestPerr(t *testing.T) {
 	for i, test := range tests {
 		SetLocale(test.locale)
 
-		if got := perr(test.input); got != test.want {
+		if got := lc.perr(test.input); got != test.want {
 			t.Error("locale:", test.locale)
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
@@ -476,7 +476,7 @@ func TestPerR(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := perR(test.input); got != test.want {
+		if got := lc.perR(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -491,7 +491,7 @@ func TestPerS(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := perS(test.input); got != test.want {
+		if got := lc.perS(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -506,7 +506,7 @@ func TestPert(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := pert(test.input); got != test.want {
+		if got := lc.pert(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -521,7 +521,7 @@ func TestPerT(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := perT(test.input); got != test.want {
+		if got := lc.perT(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -539,7 +539,7 @@ func TestPeru(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := peru(test.input); got != test.want {
+		if got := lc.peru(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -556,7 +556,7 @@ func TestPerU(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := perU(test.input); got != test.want {
+		if got := lc.perU(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -573,7 +573,7 @@ func TestPerV(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := perV(test.input); got != test.want {
+		if got := lc.perV(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -588,7 +588,7 @@ func TestPerw(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := perw(test.input); got != test.want {
+		if got := lc.perw(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -606,7 +606,7 @@ func TestPerW(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := perW(test.input); got != test.want {
+		if got := lc.perW(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -643,7 +643,7 @@ func TestPerx(t *testing.T) {
 	for i, test := range tests {
 		SetLocale(test.locale)
 
-		if got := perx(test.input); got != test.want {
+		if got := lc.perx(test.input); got != test.want {
 			t.Error("locale:", test.locale)
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
@@ -681,7 +681,7 @@ func TestPerX(t *testing.T) {
 	for i, test := range tests {
 		SetLocale(test.locale)
 
-		if got := perX(test.input); got != test.want {
+		if got := lc.perX(test.input); got != test.want {
 			t.Error("locale:", test.locale)
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
@@ -698,7 +698,7 @@ func TestPery(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := pery(test.input); got != test.want {
+		if got := lc.pery(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -713,7 +713,7 @@ func TestPerY(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := perY(test.input); got != test.want {
+		if got := lc.perY(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -728,7 +728,7 @@ func TestPerz(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := perz(test.input); got != test.want {
+		if got := lc.perz(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -743,7 +743,7 @@ func TestPerZ(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := perZ(test.input); got != test.want {
+		if got := lc.perZ(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -758,7 +758,7 @@ func TestPerper(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got := perper(test.input); got != test.want {
+		if got := lc.perper(test.input); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}

--- a/parse.go
+++ b/parse.go
@@ -8,6 +8,20 @@ import (
 // Strftime formats a time.Time. It's locale-aware, so make sure you call
 // SetLocale if needed.
 func Strftime(format string, t time.Time) string {
+	return lc.Strftime(format, t)
+}
+
+// StrftimeLoc formats a time.Time. It's locale-aware, so make sure you call
+// SetLocale if needed.
+func StrftimeLoc(locale, format string, t time.Time) (string, error) {
+	lc, err := loadLocale(locale)
+	if err != nil {
+		return "", err
+	}
+	return lc.Strftime(format, t), nil
+}
+
+func (lc *localeData) Strftime(format string, t time.Time) string {
 	if len(format) < 1 {
 		return format
 	}
@@ -17,7 +31,7 @@ func Strftime(format string, t time.Time) string {
 
 	for i := 0; i < end; i++ {
 		if format[i] == '%' && i+2 <= end {
-			buf.WriteString(parseDirective(format[i:i+2], t))
+			buf.WriteString(lc.parseDirective(format[i:i+2], t))
 			i++
 			continue
 		}
@@ -28,84 +42,84 @@ func Strftime(format string, t time.Time) string {
 	return buf.String()
 }
 
-func parseDirective(direc string, t time.Time) string {
+func (lc *localeData) parseDirective(direc string, t time.Time) string {
 	if len(direc) < 2 {
 		return direc
 	}
 
 	switch direc[:2] {
 	case "%a":
-		return pera(t)
+		return lc.pera(t)
 	case "%A":
-		return perA(t)
+		return lc.perA(t)
 	case "%b":
-		return perb(t)
+		return lc.perb(t)
 	case "%B":
-		return perB(t)
+		return lc.perB(t)
 	case "%c":
-		return perc(t)
+		return lc.perc(t)
 	case "%C":
-		return perC(t)
+		return lc.perC(t)
 	case "%d":
-		return perd(t)
+		return lc.perd(t)
 	case "%D":
-		return perD(t)
+		return lc.perD(t)
 	case "%e":
-		return pere(t)
+		return lc.pere(t)
 	case "%F":
-		return perF(t)
+		return lc.perF(t)
 	case "%g":
-		return perg(t)
+		return lc.perg(t)
 	case "%G":
-		return perG(t)
+		return lc.perG(t)
 	case "%H":
-		return perH(t)
+		return lc.perH(t)
 	case "%I":
-		return perI(t)
+		return lc.perI(t)
 	case "%j":
-		return perj(t)
+		return lc.perj(t)
 	case "%m":
-		return perm(t)
+		return lc.perm(t)
 	case "%M":
-		return perM(t)
+		return lc.perM(t)
 	case "%n":
-		return pern(t)
+		return lc.pern(t)
 	case "%p":
-		return perp(t)
+		return lc.perp(t)
 	case "%r":
-		return perr(t)
+		return lc.perr(t)
 	case "%R":
-		return perR(t)
+		return lc.perR(t)
 	case "%S":
-		return perS(t)
+		return lc.perS(t)
 	case "%t":
-		return pert(t)
+		return lc.pert(t)
 	case "%T":
-		return perT(t)
+		return lc.perT(t)
 	case "%u":
-		return peru(t)
+		return lc.peru(t)
 	case "%U":
-		return perU(t)
+		return lc.perU(t)
 	case "%V":
-		return perV(t)
+		return lc.perV(t)
 	case "%w":
-		return perw(t)
+		return lc.perw(t)
 	case "%W":
-		return perW(t)
+		return lc.perW(t)
 	case "%x":
-		return perx(t)
+		return lc.perx(t)
 	case "%X":
-		return perX(t)
+		return lc.perX(t)
 	case "%y":
-		return pery(t)
+		return lc.pery(t)
 	case "%Y":
-		return perY(t)
+		return lc.perY(t)
 	case "%z":
-		return perz(t)
+		return lc.perz(t)
 	case "%Z":
-		return perZ(t)
+		return lc.perZ(t)
 	case "%%":
-		return perper(t)
+		return lc.perper(t)
 	}
 
 	return direc

--- a/parse_test.go
+++ b/parse_test.go
@@ -7,55 +7,58 @@ import (
 )
 
 func TestParseDirective(t *testing.T) {
-	SetLocale("en_US")
+	lc, err := loadLocale("en_US")
+	if err != nil {
+		t.Fatal(err)
+	}
 	dt := time.Date(2024, 2, 22, 0, 36, 21, 795187684, time.UTC)
 
 	tests := []struct {
 		input string
 		want  string
 	}{
-		{"%a", pera(dt)},
-		{"%A", perA(dt)},
-		{"%b", perb(dt)},
-		{"%B", perB(dt)},
-		{"%c", perc(dt)},
-		{"%C", perC(dt)},
-		{"%d", perd(dt)},
-		{"%D", perD(dt)},
-		{"%e", pere(dt)},
-		{"%F", perF(dt)},
-		{"%g", perg(dt)},
-		{"%G", perG(dt)},
-		{"%H", perH(dt)},
-		{"%I", perI(dt)},
-		{"%j", perj(dt)},
-		{"%m", perm(dt)},
-		{"%M", perM(dt)},
-		{"%n", pern(dt)},
-		{"%p", perp(dt)},
-		{"%r", perr(dt)},
-		{"%R", perR(dt)},
-		{"%S", perS(dt)},
-		{"%t", pert(dt)},
-		{"%T", perT(dt)},
-		{"%u", peru(dt)},
-		{"%U", perU(dt)},
-		{"%V", perV(dt)},
-		{"%w", perw(dt)},
-		{"%W", perW(dt)},
-		{"%x", perx(dt)},
-		{"%X", perX(dt)},
-		{"%y", pery(dt)},
-		{"%Y", perY(dt)},
-		{"%z", perz(dt)},
-		{"%Z", perZ(dt)},
-		{"%%", perper(dt)},
+		{"%a", lc.pera(dt)},
+		{"%A", lc.perA(dt)},
+		{"%b", lc.perb(dt)},
+		{"%B", lc.perB(dt)},
+		{"%c", lc.perc(dt)},
+		{"%C", lc.perC(dt)},
+		{"%d", lc.perd(dt)},
+		{"%D", lc.perD(dt)},
+		{"%e", lc.pere(dt)},
+		{"%F", lc.perF(dt)},
+		{"%g", lc.perg(dt)},
+		{"%G", lc.perG(dt)},
+		{"%H", lc.perH(dt)},
+		{"%I", lc.perI(dt)},
+		{"%j", lc.perj(dt)},
+		{"%m", lc.perm(dt)},
+		{"%M", lc.perM(dt)},
+		{"%n", lc.pern(dt)},
+		{"%p", lc.perp(dt)},
+		{"%r", lc.perr(dt)},
+		{"%R", lc.perR(dt)},
+		{"%S", lc.perS(dt)},
+		{"%t", lc.pert(dt)},
+		{"%T", lc.perT(dt)},
+		{"%u", lc.peru(dt)},
+		{"%U", lc.perU(dt)},
+		{"%V", lc.perV(dt)},
+		{"%w", lc.perw(dt)},
+		{"%W", lc.perW(dt)},
+		{"%x", lc.perx(dt)},
+		{"%X", lc.perX(dt)},
+		{"%y", lc.pery(dt)},
+		{"%Y", lc.perY(dt)},
+		{"%z", lc.perz(dt)},
+		{"%Z", lc.perZ(dt)},
+		{"%%", lc.perper(dt)},
 		{"--", "--"},
 		{"", ""},
 	}
 
 	for i, test := range tests {
-		if got := parseDirective(test.input, dt); got != test.want {
+		if got := lc.parseDirective(test.input, dt); got != test.want {
 			t.Errorf(gotWantIdx, i, got, test.want)
 		}
 	}
@@ -93,9 +96,24 @@ func ExampleStrftime() {
 	// Output: Sun 02 Jan 2000 03:04:05 AM UTC
 }
 
-func ExampleStrftime_withLocale() {
-	SetLocale("es_MX")
+func ExampleStrftimeLoc() {
 	t := time.Date(2015, 12, 25, 3, 2, 1, 0, time.UTC)
-	fmt.Println(Strftime("%A, %d de %B de %Y", t))
+	txt, err := StrftimeLoc("es_MX", "%A, %d de %B de %Y", t)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println(txt)
 	// Output: viernes, 25 de diciembre de 2015
+}
+
+func ExampleLocalizer() {
+	t := time.Date(2015, 12, 25, 3, 2, 1, 0, time.UTC)
+	l, err := NewLocalizer("da_DK")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println(l.Strftime("%A den %d. %B %Y", t))
+	// Output: fredag den 25. december 2015
 }


### PR DESCRIPTION
With this patch it will be possible to do translations to different languages without having to modify global package state.

This should remain backwards compatible.

A cache is kept for quick access to already loaded locales.

Examples of usage has been added and README updated.